### PR TITLE
Support for Asynchronous Tournaments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Latest
 
+- Added new match results that support asynchronous tournaments.
 - Fixed the auto-pair algorithm to more correctly weight score differences.
 - Made some screens more printer-friendly.
 - Changed K-factor calculation to be more conservative.

--- a/__tests__/__snapshots__/Pairing_test.bs.js.snap
+++ b/__tests__/__snapshots__/Pairing_test.bs.js.snap
@@ -393,6 +393,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -533,6 +548,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -675,6 +705,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -815,6 +860,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -957,6 +1017,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -1097,6 +1172,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -1239,6 +1329,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -1379,6 +1484,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -1521,6 +1641,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -1661,6 +1796,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -1803,6 +1953,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -1943,6 +2108,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -2085,6 +2265,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -2225,6 +2420,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -2367,6 +2577,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -2507,6 +2732,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -2649,6 +2889,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -2789,6 +3044,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -2931,6 +3201,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -3071,6 +3356,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -3213,6 +3513,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -3353,6 +3668,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -3495,6 +3825,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -3635,6 +3980,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -3777,6 +4137,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -3917,6 +4292,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -4059,6 +4449,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -4199,6 +4604,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -4341,6 +4761,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -4482,6 +4917,21 @@ Object {
                         >
                           Draw
                         </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
+                        </option>
                       </select>
                     </td>
                     <td
@@ -4622,6 +5072,21 @@ Object {
                           value="draw"
                         >
                           Draw
+                        </option>
+                        <option
+                          value="aborted"
+                        >
+                          Aborted
+                        </option>
+                        <option
+                          value="whiteAborted"
+                        >
+                          White Aborted
+                        </option>
+                        <option
+                          value="blackAborted"
+                        >
+                          Black Aborted
                         </option>
                       </select>
                     </td>
@@ -5103,6 +5568,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -5243,6 +5723,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -5385,6 +5880,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -5525,6 +6035,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -5667,6 +6192,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -5807,6 +6347,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -5949,6 +6504,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -6089,6 +6659,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -6231,6 +6816,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -6371,6 +6971,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -6513,6 +7128,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -6653,6 +7283,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -6795,6 +7440,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -6935,6 +7595,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -7077,6 +7752,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -7217,6 +7907,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -7359,6 +8064,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -7499,6 +8219,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -7641,6 +8376,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -7781,6 +8531,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -7923,6 +8688,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -8063,6 +8843,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -8205,6 +9000,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -8345,6 +9155,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -8487,6 +9312,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -8627,6 +9467,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -8769,6 +9624,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -8909,6 +9779,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>
@@ -9051,6 +9936,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -9192,6 +10092,21 @@ Object {
                       >
                         Draw
                       </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
+                      </option>
                     </select>
                   </td>
                   <td
@@ -9332,6 +10247,21 @@ Object {
                         value="draw"
                       >
                         Draw
+                      </option>
+                      <option
+                        value="aborted"
+                      >
+                        Aborted
+                      </option>
+                      <option
+                        value="whiteAborted"
+                      >
+                        White Aborted
+                      </option>
+                      <option
+                        value="blackAborted"
+                      >
+                        Black Aborted
                       </option>
                     </select>
                   </td>

--- a/src/Data/Data_Match.res
+++ b/src/Data/Data_Match.res
@@ -11,13 +11,16 @@ module Option = Belt.Option
 
 /* Not to be confused with `Belt.Result` */
 module Result = {
-  type t = WhiteWon | BlackWon | Draw | NotSet
+  type t = WhiteWon | BlackWon | Draw | Aborted | WhiteAborted | BlackAborted | NotSet
 
   let toString = x =>
     switch x {
     | WhiteWon => "whiteWon"
     | BlackWon => "blackWon"
     | Draw => "draw"
+    | Aborted => "aborted"
+    | WhiteAborted => "whiteAborted"
+    | BlackAborted => "blackAborted"
     | NotSet => "notSet"
     }
 
@@ -26,6 +29,9 @@ module Result = {
     | "whiteWon" => WhiteWon
     | "blackWon" => BlackWon
     | "draw" => Draw
+    | "aborted" => Aborted
+    | "whiteAborted" => WhiteAborted
+    | "blackAborted" => BlackAborted
     | _ => NotSet
     }
 
@@ -46,7 +52,9 @@ module Result = {
     switch t {
     | WhiteWon => BlackWon
     | BlackWon => WhiteWon
-    | (NotSet | Draw) as t => t
+    | WhiteAborted => BlackAborted
+    | BlackAborted => WhiteAborted
+    | (NotSet | Draw | Aborted) as t => t
     }
 }
 

--- a/src/Data/Data_Match.res
+++ b/src/Data/Data_Match.res
@@ -111,12 +111,11 @@ let encode = data =>
     ("result", data.result->Result.encode),
   ])->Js.Json.object_
 
-let manualPair = (~white: Data_Player.t, ~black: Data_Player.t, result, byeValue) => {
+let manualPair = (~white: Data_Player.t, ~black: Data_Player.t, result: Result.t, byeValue) => {
   id: Id.random(),
   result: switch result {
-  | Result.NotSet =>
-    Result.scoreByeMatch(~byeValue, ~white=white.id, ~black=black.id, ~default=NotSet)
-  | WhiteWon | BlackWon | Draw => result
+  | NotSet => Result.scoreByeMatch(~byeValue, ~white=white.id, ~black=black.id, ~default=NotSet)
+  | WhiteWon | BlackWon | Draw | Aborted | WhiteAborted | BlackAborted => result
   },
   whiteId: white.id,
   blackId: black.id,
@@ -131,7 +130,9 @@ let swapColors = match => {
   result: switch match.result {
   | WhiteWon => BlackWon
   | BlackWon => WhiteWon
-  | (Draw | NotSet) as x => x
+  | WhiteAborted => BlackAborted
+  | BlackAborted => WhiteAborted
+  | (Draw | NotSet | Aborted) as x => x
   },
   whiteId: match.blackId,
   blackId: match.whiteId,

--- a/src/Data/Data_Match.resi
+++ b/src/Data/Data_Match.resi
@@ -6,7 +6,7 @@
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 module Result: {
-  type t = WhiteWon | BlackWon | Draw | NotSet
+  type t = WhiteWon | BlackWon | Draw | Aborted | WhiteAborted | BlackAborted | NotSet
 
   let toString: t => string
 

--- a/src/Data/Data_Scoring.res
+++ b/src/Data/Data_Scoring.res
@@ -51,20 +51,20 @@ module Score = {
 
   let fromResultWhite = (x: Data_Match.Result.t) =>
     switch x {
-    | WhiteWon => One
-    | BlackWon => Zero
     | Draw => Half
     /* This loses data, so is a one-way trip. Use with prudence! */
-    | NotSet => Zero
+    | (WhiteWon | BlackAborted) => One
+    | (BlackWon | WhiteAborted) => Zero
+    | (NotSet | Aborted) => Zero
     }
 
   let fromResultBlack = (x: Data_Match.Result.t) =>
     switch x {
-    | WhiteWon => Zero
-    | BlackWon => One
     | Draw => Half
     /* This loses data, so is a one-way trip. Use with prudence! */
-    | NotSet => Zero
+    | (WhiteWon | BlackAborted) => Zero
+    | (BlackWon | WhiteAborted) => One
+    | (NotSet | Aborted) => Zero
     }
 }
 
@@ -363,7 +363,7 @@ let fromTournament = (~roundList, ~scoreAdjustments) =>
   ->MutableQueue.reduce(Map.make(~id=Data_Id.id), (acc, match: Data_Match.t) =>
     switch match.result {
     | NotSet => acc
-    | WhiteWon | BlackWon | Draw =>
+    | WhiteWon | BlackWon | Draw | Aborted | WhiteAborted | BlackAborted =>
       let whiteUpdate = update(
         ~playerId=match.whiteId,
         ~origRating=match.whiteOrigRating,

--- a/src/Data/Data_Scoring.res
+++ b/src/Data/Data_Scoring.res
@@ -52,7 +52,6 @@ module Score = {
   let fromResultWhite = (x: Data_Match.Result.t) =>
     switch x {
     | Draw => Half
-    /* This loses data, so is a one-way trip. Use with prudence! */
     | (WhiteWon | BlackAborted) => One
     | (BlackWon | WhiteAborted) => Zero
     | (NotSet | Aborted) => Zero
@@ -61,7 +60,6 @@ module Score = {
   let fromResultBlack = (x: Data_Match.Result.t) =>
     switch x {
     | Draw => Half
-    /* This loses data, so is a one-way trip. Use with prudence! */
     | (WhiteWon | BlackAborted) => Zero
     | (BlackWon | WhiteAborted) => One
     | (NotSet | Aborted) => Zero

--- a/src/PageTournament/PageRound.res
+++ b/src/PageTournament/PageRound.res
@@ -119,7 +119,7 @@ module MatchRow = {
         let (whiteNewRating, blackNewRating) = switch (newResult, whiteOpt, blackOpt) {
         | (_, None, _)
         | (_, _, None)
-        | (NotSet | Aborted | WhiteAborted | BlackAborted, _, _) => (m.whiteOrigRating, m.blackOrigRating)
+        | (Aborted | WhiteAborted | BlackAborted | NotSet, _, _) => (m.whiteOrigRating, m.blackOrigRating)
         | (BlackWon | WhiteWon | Draw, Some(white), Some(black)) =>
           Ratings.calcNewRatings(
             ~whiteRating=m.whiteOrigRating,

--- a/src/PageTournament/PageRound.res
+++ b/src/PageTournament/PageRound.res
@@ -72,23 +72,39 @@ module MatchRow = {
     let resultDisplay = (playerColor: Scoring.Color.t) => {
       let won = <Icons.Award className="pageround__wonicon" />
       let lost = <Externals.VisuallyHidden> {React.string("Lost")} </Externals.VisuallyHidden>
+      let aborted = 
+        <span
+          ariaLabel="Draw" role="img" style={ReactDOMRe.Style.make(~filter="grayscale(60%)", ())}>
+          {React.string(`❌`)}
+        </span>
       switch m.result {
       | NotSet => <Externals.VisuallyHidden> {React.string("Not set")} </Externals.VisuallyHidden>
-      | (Draw | Aborted) =>
+      | (Draw) =>
         /* TODO: find a better icon for draws. */
         <span
           ariaLabel="Draw" role="img" style={ReactDOMRe.Style.make(~filter="grayscale(70%)", ())}>
           {React.string(`🤝`)}
         </span>
-      | (BlackWon | WhiteAborted) =>
+      | BlackWon =>
         switch playerColor {
         | White => lost
         | Black => won
         }
-      | (WhiteWon | BlackAborted) =>
+      | WhiteWon =>
         switch playerColor {
         | White => won
         | Black => lost
+        }
+      | Aborted => aborted
+      | WhiteAborted =>
+        switch playerColor {
+        | White => aborted
+        | Black => won
+        }
+      | BlackAborted =>
+        switch playerColor {
+        | White => won
+        | Black => aborted
         }
       }
     }
@@ -104,7 +120,8 @@ module MatchRow = {
         | (_, None, _)
         | (_, _, None)
         | (NotSet, _, _) => (m.whiteOrigRating, m.blackOrigRating)
-        | (BlackWon | WhiteWon | Draw | Aborted | WhiteAborted | BlackAborted, Some(white), Some(black)) =>
+        | (Aborted | WhiteAborted | BlackAborted, _, _) => (m.whiteOrigRating, m.blackOrigRating)
+        | (BlackWon | WhiteWon | Draw, Some(white), Some(black)) =>
           Ratings.calcNewRatings(
             ~whiteRating=m.whiteOrigRating,
             ~blackRating=m.blackOrigRating,

--- a/src/PageTournament/PageRound.res
+++ b/src/PageTournament/PageRound.res
@@ -74,18 +74,18 @@ module MatchRow = {
       let lost = <Externals.VisuallyHidden> {React.string("Lost")} </Externals.VisuallyHidden>
       switch m.result {
       | NotSet => <Externals.VisuallyHidden> {React.string("Not set")} </Externals.VisuallyHidden>
-      | Draw =>
+      | (Draw | Aborted) =>
         /* TODO: find a better icon for draws. */
         <span
           ariaLabel="Draw" role="img" style={ReactDOMRe.Style.make(~filter="grayscale(70%)", ())}>
           {React.string(`🤝`)}
         </span>
-      | BlackWon =>
+      | (BlackWon | WhiteAborted) =>
         switch playerColor {
         | White => lost
         | Black => won
         }
-      | WhiteWon =>
+      | (WhiteWon | BlackAborted) =>
         switch playerColor {
         | White => won
         | Black => lost
@@ -104,7 +104,7 @@ module MatchRow = {
         | (_, None, _)
         | (_, _, None)
         | (NotSet, _, _) => (m.whiteOrigRating, m.blackOrigRating)
-        | (BlackWon | WhiteWon | Draw, Some(white), Some(black)) =>
+        | (BlackWon | WhiteWon | Draw | Aborted | WhiteAborted | BlackAborted, Some(white), Some(black)) =>
           Ratings.calcNewRatings(
             ~whiteRating=m.whiteOrigRating,
             ~blackRating=m.blackOrigRating,
@@ -125,7 +125,7 @@ module MatchRow = {
             playersDispatch(Set(blackId, {...black, matchCount: black.matchCount + 1}))
           )
         /* If the result is being un-scored, decrement the matchCounts */
-        | WhiteWon | BlackWon | Draw if newResult == NotSet =>
+        | WhiteWon | BlackWon | Draw | Aborted | WhiteAborted | BlackAborted if newResult == NotSet =>
           Option.forEach(whiteOpt, white =>
             playersDispatch(Set(whiteId, {...white, matchCount: white.matchCount - 1}))
           )
@@ -133,7 +133,7 @@ module MatchRow = {
             playersDispatch(Set(blackId, {...black, matchCount: black.matchCount - 1}))
           )
         /* Simply update the players with new ratings. */
-        | WhiteWon | BlackWon | Draw =>
+        | WhiteWon | BlackWon | Draw | Aborted | WhiteAborted | BlackAborted =>
           Option.forEach(whiteOpt, white => playersDispatch(Set(whiteId, white)))
           Option.forEach(blackOpt, black => playersDispatch(Set(blackId, black)))
         }

--- a/src/PageTournament/PageRound.res
+++ b/src/PageTournament/PageRound.res
@@ -79,7 +79,7 @@ module MatchRow = {
         </span>
       switch m.result {
       | NotSet => <Externals.VisuallyHidden> {React.string("Not set")} </Externals.VisuallyHidden>
-      | (Draw) =>
+      | Draw =>
         /* TODO: find a better icon for draws. */
         <span
           ariaLabel="Draw" role="img" style={ReactDOMRe.Style.make(~filter="grayscale(70%)", ())}>

--- a/src/PageTournament/PageRound.res
+++ b/src/PageTournament/PageRound.res
@@ -186,6 +186,9 @@ module MatchRow = {
             <option value={Match.Result.toString(WhiteWon)}> {React.string("White won")} </option>
             <option value={Match.Result.toString(BlackWon)}> {React.string("Black won")} </option>
             <option value={Match.Result.toString(Draw)}> {React.string("Draw")} </option>
+            <option value={Match.Result.toString(Aborted)}> {React.string("Aborted")} </option>
+            <option value={Match.Result.toString(WhiteAborted)}> {React.string("White Aborted")} </option>
+            <option value={Match.Result.toString(BlackAborted)}> {React.string("Black Aborted")} </option>
           </select>
         </Utils.TestId>
       </td>

--- a/src/PageTournament/PageRound.res
+++ b/src/PageTournament/PageRound.res
@@ -119,8 +119,7 @@ module MatchRow = {
         let (whiteNewRating, blackNewRating) = switch (newResult, whiteOpt, blackOpt) {
         | (_, None, _)
         | (_, _, None)
-        | (NotSet, _, _) => (m.whiteOrigRating, m.blackOrigRating)
-        | (Aborted | WhiteAborted | BlackAborted, _, _) => (m.whiteOrigRating, m.blackOrigRating)
+        | (NotSet | Aborted | WhiteAborted | BlackAborted, _, _) => (m.whiteOrigRating, m.blackOrigRating)
         | (BlackWon | WhiteWon | Draw, Some(white), Some(black)) =>
           Ratings.calcNewRatings(
             ~whiteRating=m.whiteOrigRating,

--- a/src/PageTournament/PageTourney.res
+++ b/src/PageTournament/PageTourney.res
@@ -104,9 +104,12 @@ module Sidebar = {
             /* Don't change players who haven't scored. */
             switch result {
             | NotSet => ()
+            | WhiteWon 
             | BlackWon
             | Draw
-            | WhiteWon =>
+            | Aborted
+            | WhiteAborted
+            | BlackAborted =>
               [(whiteId, whiteOrigRating), (blackId, blackOrigRating)]->Array.forEach(((
                 id,
                 rating,

--- a/src/PageTournament/PairPicker.res
+++ b/src/PageTournament/PairPicker.res
@@ -326,6 +326,9 @@ module Stage = {
               <option value={Match.Result.toString(WhiteWon)}> {React.string("White won")} </option>
               <option value={Match.Result.toString(BlackWon)}> {React.string("Black won")} </option>
               <option value={Match.Result.toString(Draw)}> {React.string("Draw")} </option>
+              <option value={Match.Result.toString(Aborted)}> {React.string("Aborted")} </option>
+              <option value={Match.Result.toString(WhiteAborted)}> {React.string("White Aborted")} </option>
+              <option value={Match.Result.toString(BlackAborted)}> {React.string("Black Aborted")} </option>
             </select>
           </Utils.TestId>
         </label>


### PR DESCRIPTION
I'm using Coronate to conduct tournaments between friends similarly to how [lichess4545](https://www.lichess4545.com/) conducts a tournament.

Pairings are assigned and players are expected to play their games and report back within a timeframe.

Playing this way adds a few result states and I'd like to have them supported, probably behind a setting in the tournament as I'm sure it wouldn't apply to most use cases.

**Aborted** - Match never occured, no blame placed. No round points awarded. ELO should remain the same.
**WhiteAborted** - Match never occured, blame placed on White. Round point awarded to Black. ELO should remain the same.
**BlackAborted** - Match never occured, blame placed on Black. Round point awarded to White. ELO should remain the same.