### PR TITLE
Fix Tournament active player roster table not refreshing automatically

### DIFF
--- a/src/PageTournament/PageTourneyPlayers.res
+++ b/src/PageTournament/PageTourneyPlayers.res
@@ -377,6 +377,13 @@ let make = (~tournament: LoadTournament.t) => {
     ~column=sortFirstName,
     ~isDescending=false,
   )
+
+  // update the current roster table when activePlayers changes
+  React.useEffect1(() => {
+    tableDispatch(Hooks.SetTable(Map.valuesToArray(activePlayers)))
+    None
+  }, [activePlayers])
+
   let {playerIds, roundList, byeQueue, _} = tourney
   let (isSelecting, setIsSelecting) = React.useState(() => Set.isEmpty(playerIds))
   let matches = Rounds.rounds2Matches(roundList)


### PR DESCRIPTION
Fixes issue #100, insofar as the active player table was not being refreshed after new players were added.