### PR TITLE
Highlight incomplete games

### DIFF
--- a/src/PageTournament/PageRound.res
+++ b/src/PageTournament/PageRound.res
@@ -341,14 +341,30 @@ module RoundTable = {
     ~scoreData=?,
   ) => {
     let (config, _) = Db.useConfig()
+
+    let incompleteGamesCount =
+      matches
+      ->Array.keep((m: Data.Match.t) => m.result == NotSet)
+      ->Array.length
+
     <table className="pageround__table">
       {if Js.Array.length(matches) == 0 {
         React.null
       } else {
         <>
           <caption className={isCompact ? "title-30" : "title-40"}>
-            {React.string("Round ")}
-            {React.int(roundId + 1)}
+            <div>
+              {React.string("Round ")}
+              {React.int(roundId + 1)}
+            </div>
+            {if incompleteGamesCount > 0 {
+              <div className="pageround__gamesinprogress__caption">
+                {React.string("Incomplete Games: ")}
+                {React.int(incompleteGamesCount)}
+              </div>
+            } else {
+              React.null
+            }}
           </caption>
           <thead className="pageround__table-head">
             <tr>

--- a/src/style.css
+++ b/src/style.css
@@ -926,6 +926,12 @@ li.player.missing {
   color: var(--yellow-70);
 }
 
+.pageround__gamesinprogress__caption {
+  margin-top: 0.2em;
+  margin-bottom: 0.2em;
+  font-size: smaller;
+  background-color: lightyellow;
+}
 .pageround__gameinprogress {
   background-color: lightyellow;
 }


### PR DESCRIPTION
First of all, thanks.

We successfully hosted a [100+ player tournament](https://github.com/user-attachments/assets/40b6b8c5-6224-43b0-a5ed-6b383c3b655d) using Coronate as our tool this weekend. Thanks so much for this great piece of software! It makes it so easy to manage such a large event. I have previously used it to host small company tournaments at a slow daily pace, so this was the first time I actually used it in "production" in a fast past environment with the pressure of 100-200 people waiting on us in between rounds. 

Overall everything went relatively smoothly. We hit a snag in the first round where we were trying to remove/add active players to the tournament before the round was finished, and we essentially got soft-locked and were unable to start a new round, and the reason wasn't obvious. We tried to make sure all games had results and that there were no retroactive unmatched players, but we weren't able to start a new round. I am waiting for them to send me the backup files we used in the tournament so I can diagnose that issue and see if it was a bug, or if it was user error. Either way, we had to restart the tournament. From then on, we only changed the active player list after finalizing the current round, and things worked smoothly from there on.

One question we found we were constantly asking each round was "How many games are still active?, and which board are they at?" This PR is hopefully a nice solution to this issue. I highlight active/incomplete games with a light yellow background, so they visually stand out when scrolling through a long list, and also show the total count of incomplete games under the round number if there is at least one incomplete game. These changes should make it much easier to see where we forgot to set a result.

<img width="1725" height="908" alt="image" src="https://github.com/user-attachments/assets/c8e8963a-532a-4105-8ddb-29618bf7ae7c" />
<img width="1916" height="961" alt="image" src="https://github.com/user-attachments/assets/012dbb35-1ade-4169-8186-1f97a33a4ba9" />
